### PR TITLE
CI: build in release mode

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -3,7 +3,7 @@ name: MSBuild
 on: push
 env:
   SOLUTION_FILE_PATH: .
-  BUILD_CONFIGURATION: Debug
+  BUILD_CONFIGURATION: Release
 
 permissions:
   contents: read
@@ -20,11 +20,15 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Build
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        mkdir x64/${{env.BUILD_CONFIGURATION}}/sid1
+        mv big4-dc–disasm/sid1/sidbase.bin x64/${{env.BUILD_CONFIGURATION}}/sid1/sidbase.bin
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         path: |
+          x64/**/*.bin
           x64/**/*.exe
           x64/**/*.pdb

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,13 +22,10 @@ jobs:
     - name: Build
       run: |
         msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
-        mkdir x64/${{env.BUILD_CONFIGURATION}}/sid1
-        mv big4-dc–disasm/sid1/sidbase.bin x64/${{env.BUILD_CONFIGURATION}}/sid1/sidbase.bin
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         path: |
-          x64/**/*.bin
           x64/**/*.exe
           x64/**/*.pdb

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,8 +20,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Build
-      run: |
-        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Turns out Microsoft doesn't actually ship debug DLLs outside of VS environment, meaning if user obtain debug build without MSVC installed they can't run it.

Please merge as squash.